### PR TITLE
fix(LiveStream): add a trailing slash at the end of an URL if it is m…

### DIFF
--- a/livestream/src/main/java/video/api/livestream/ApiVideoLiveStream.kt
+++ b/livestream/src/main/java/video/api/livestream/ApiVideoLiveStream.kt
@@ -263,14 +263,14 @@ constructor(
      */
     fun startStreaming(
         streamKey: String,
-        url: String? = context.getString(R.string.default_rtmp_url),
+        url: String = context.getString(R.string.default_rtmp_url),
     ) {
         if (rtmpCamera2.isStreaming) {
             throw UnsupportedOperationException("Stream is already started")
         }
 
         prepareEncoders()
-        rtmpCamera2.startStream(url + streamKey)
+        rtmpCamera2.startStream(url.addTrailingSlashIfNeeded() + streamKey)
     }
 
     /**

--- a/livestream/src/main/java/video/api/livestream/Extensions.kt
+++ b/livestream/src/main/java/video/api/livestream/Extensions.kt
@@ -1,0 +1,10 @@
+package video.api.livestream
+
+/**
+ * Add a slash at the end of a [String] only if it is missing.
+ *
+ * @return the given string with a trailing slash.
+ */
+fun String.addTrailingSlashIfNeeded(): String {
+    return if (this.endsWith("/")) this else "$this/"
+}

--- a/livestream/src/test/java/video/api/livestream/ExtensionsKtTest.kt
+++ b/livestream/src/test/java/video/api/livestream/ExtensionsKtTest.kt
@@ -1,0 +1,13 @@
+package video.api.livestream
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class ExtensionsKtTest {
+
+    @Test
+    fun addTrailingSlashIfNeeded() {
+        assertEquals("abcde/", "abcde".addTrailingSlashIfNeeded())
+        assertEquals("abcde/", "abcde/".addTrailingSlashIfNeeded())
+    }
+}


### PR DESCRIPTION
## Identify the Bug
See https://github.com/apivideo/api.video-reactnative-live-stream/issues/8

## Description of the Change
Add a trailing slash in the url if it does not end with a slash.
